### PR TITLE
Add multiple trajectory support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ not load the ES module scripts correctly.
 
 - 2D random walk visualisation using HTML canvas
 - Edge reinforced random walk simulator with configurable parameters
+- Run multiple walks at once, each drawn with a unique colour

--- a/web/index.html
+++ b/web/index.html
@@ -14,6 +14,7 @@
   <div id="controls">
     <button id="run">Run Random Walk</button>
     <input id="steps" type="number" value="1000" min="10" /> Steps
+    <input id="count" type="number" value="1" min="1" style="width:4em" /> Trajectories
     <select id="type">
       <option value="simple">Simple</option>
       <option value="erw">Edge Reinforced</option>

--- a/web/main.js
+++ b/web/main.js
@@ -14,15 +14,22 @@ function init() {
   document.getElementById('run').onclick = () => {
     resize();
     const steps = parseInt(document.getElementById('steps').value, 10);
+    const count = parseInt(document.getElementById('count').value, 10);
     const type = document.getElementById('type').value;
-    let result;
-    if (type === 'erw') {
-      const strength = parseFloat(document.getElementById('strength').value);
-      const delay = parseInt(document.getElementById('delay').value, 10);
-      const memory = parseInt(document.getElementById('memory').value, 10);
-      result = edgeReinforcedWalk(steps, strength, delay, memory);
-    } else {
-      result = randomWalk(steps);
+
+    const walks = [];
+    for (let n = 0; n < count; n++) {
+      let result;
+      if (type === 'erw') {
+        const strength = parseFloat(document.getElementById('strength').value);
+        const delay = parseInt(document.getElementById('delay').value, 10);
+        const memory = parseInt(document.getElementById('memory').value, 10);
+        result = edgeReinforcedWalk(steps, strength, delay, memory);
+      } else {
+        result = randomWalk(steps);
+      }
+      const hue = (n * 360) / count;
+      walks.push({ result, color: `hsl(${hue}, 100%, 50%)` });
     }
 
     ctx.clearRect(0, 0, canvas.width, canvas.height);
@@ -30,20 +37,25 @@ function init() {
     const scale = 10;
     let i = 1;
     const drawStep = () => {
-      if (i >= result.x.length) return;
+      if (i >= steps + 1) return;
 
       ctx.fillStyle = 'rgba(0, 0, 0, 0.02)';
       ctx.fillRect(0, 0, canvas.width, canvas.height);
 
-      ctx.beginPath();
-      const x1 = canvas.width / 2 + result.x[i - 1] * scale;
-      const y1 = canvas.height / 2 + result.y[i - 1] * scale;
-      const x2 = canvas.width / 2 + result.x[i] * scale;
-      const y2 = canvas.height / 2 + result.y[i] * scale;
-      ctx.moveTo(x1, y1);
-      ctx.lineTo(x2, y2);
-      ctx.strokeStyle = 'lime';
-      ctx.stroke();
+      walks.forEach(w => {
+        const { result, color } = w;
+        if (i < result.x.length) {
+          ctx.beginPath();
+          const x1 = canvas.width / 2 + result.x[i - 1] * scale;
+          const y1 = canvas.height / 2 + result.y[i - 1] * scale;
+          const x2 = canvas.width / 2 + result.x[i] * scale;
+          const y2 = canvas.height / 2 + result.y[i] * scale;
+          ctx.moveTo(x1, y1);
+          ctx.lineTo(x2, y2);
+          ctx.strokeStyle = color;
+          ctx.stroke();
+        }
+      });
 
       i += 1;
       requestAnimationFrame(drawStep);


### PR DESCRIPTION
## Summary
- allow generating multiple random walks at once
- color each trajectory uniquely
- document the new feature

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687760f37d50832aa468db186bd8c65c